### PR TITLE
rebuild rapidjson with fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf
+*.patch text eol=lf

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,18 +1,15 @@
 mkdir build
 cd build
 
-cmake -G "%CMAKE_GENERATOR%" ^
+cmake -G "Ninja" %CMAKE_ARGS% ^
       -D RAPIDJSON_HAS_STDSTRING=ON ^
-      -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -D RAPIDJSON_BUILD_TESTS=OFF ^
       -D RAPIDJSON_BUILD_EXAMPLES=OFF ^
       -D RAPIDJSON_BUILD_DOC=OFF ^
-      -D CMAKE_VERBOSE_MAKEFILE=ON ^
-      -D CMAKE_BUILD_TYPE=Release ^
       ..
 
 if errorlevel 1 exit 1
 
-cmake --build . --config Release --target install
+cmake --build . --target install -j%CPU_COUNT%
 
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,13 +3,11 @@
 mkdir build
 cd build
 
-cmake -DRAPIDJSON_HAS_STDSTRING=ON \
-      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+cmake -G "Ninja" ${CMAKE_ARGS} \
+      -DRAPIDJSON_HAS_STDSTRING=ON \
       -DRAPIDJSON_BUILD_TESTS=OFF \
       -DRAPIDJSON_BUILD_EXAMPLES=OFF \
       -DRAPIDJSON_BUILD_DOC=OFF \
-      -DCMAKE_VERBOSE_MAKEFILE=ON \
-      -DCMAKE_BUILD_TYPE=release \
       ..
 
-make install
+cmake --build . --target install -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,26 @@
 {% set name = "rapidjson" %}
 {% set version = "1.1.0" %}
-{% set sha256 = "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/miloyip/rapidjson/archive/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/Tencent/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e
+  patches:
+    - patches/0001-Fix-assignment-error.patch
+    - patches/0002-Increase-CMake-minimum-required.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
-    - cmake
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
-    - make  # [unix]
+    - cmake
+    - ninja
 
 test:
   commands:
@@ -30,14 +32,14 @@ test:
     - if exist %LIBRARY_PREFIX%\lib\cmake\RapidJSON\RapidJSONConfigVersion.cmake (exit 0) else (exit 1)  # [win]
 
 about:
-  home: https://rapidjson.org/
+  home: https://rapidjson.org
   summary: A fast JSON parser/generator for C++ with both SAX/DOM style API
   license: MIT
   license_file: license.txt
   license_family: MIT
   summary: A fast JSON parser/generator for C++ with both SAX/DOM style API
-  dev_url: https://github.com/miloyip/rapidjson
-  doc_url: https://rapidjson.org/
+  dev_url: https://github.com/Tencent/rapidjson
+  doc_url: https://rapidjson.org
   description: |
     RapidJSON is a self-contained and header only parser/generator for C++, which
     supports both SAX and DOM style API, with no external dependencies such as

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
+    - ninja-base
 
 test:
   commands:

--- a/recipe/patches/0001-Fix-assignment-error.patch
+++ b/recipe/patches/0001-Fix-assignment-error.patch
@@ -1,0 +1,40 @@
+From dead384f1b8d69f63789c2e7967dbcd609527e55 Mon Sep 17 00:00:00 2001
+From: Mikolaj Gralczyk <mgralczyk@anaconda.com>
+Date: Wed, 19 Nov 2025 14:12:44 +0100
+Subject: [PATCH] Fix assignment error
+
+The problem appears with clang 20 and from gcc 14.
+The issue is described here:
+https://github.com/Tencent/rapidjson/issues/2277
+
+The fix comes from PR:
+https://github.com/Tencent/rapidjson/pull/719
+---
+ include/rapidjson/document.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/rapidjson/document.h b/include/rapidjson/document.h
+index e3e20dfb..19f5a6a5 100644
+--- a/include/rapidjson/document.h
++++ b/include/rapidjson/document.h
+@@ -316,8 +316,6 @@ struct GenericStringRef {
+ 
+     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
+ 
+-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+-
+     //! implicit conversion to plain CharType pointer
+     operator const Ch *() const { return s; }
+ 
+@@ -328,6 +326,8 @@ private:
+     //! Disallow construction from non-const array
+     template<SizeType N>
+     GenericStringRef(CharType (&str)[N]) /* = delete */;
++    //! Copy assignment operator not permitted - immutable type
++    GenericStringRef& operator=(const GenericStringRef& rhs) /* = delete */;
+ };
+ 
+ //! Mark a character pointer as constant string
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipe/patches/0002-Increase-CMake-minimum-required.patch
+++ b/recipe/patches/0002-Increase-CMake-minimum-required.patch
@@ -1,0 +1,35 @@
+From 5ae3811f0ac503c6f3b774a1214bbec933bbb49e Mon Sep 17 00:00:00 2001
+From: Mikolaj Gralczyk <mgralczyk@anaconda.com>
+Date: Thu, 20 Nov 2025 13:57:40 +0100
+Subject: [PATCH] Increase CMake minimum required
+
+Compatibility with CMake < 3.5 has been removed from CMake's newer versions.
+This caused compilation errors. The fix comes from:
+https://github.com/Tencent/rapidjson/pull/2250
+
+Additionally, a policy for backward compatibility was added.
+---
+ CMakeLists.txt | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ceda71b1..b59f86cf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,10 +1,6 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+-if(POLICY CMP0025)
+-  # detect Apple's Clang
+-  cmake_policy(SET CMP0025 NEW)
+-endif()
+-if(POLICY CMP0054)
+-  cmake_policy(SET CMP0054 NEW)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5...4.0)
++if(POLICY CMP0175)
++    cmake_policy(SET CMP0175 OLD)
+ endif()
+ 
+ SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
[PKG-10884](https://anaconda.atlassian.net/browse/PKG-10884)
dev_url: https://github.com/Tencent/rapidjson/tree/v1.1.0

In this PR:
- fix build error for newer gcc and clang version by providing _0001-Fix-assignment-error.patch_
- upgrade cmake minimum required as it is no longer supported by cmake >4 (_0002-Increase-CMake-minimum-required.patch_)
- change dev url
- switch from _make_ to _ninja_ & clean build scripts
- clean recipe

*NOTE*: Rapidjson hasn't been updated since 2016. The only way to update this feedstock is through patching.

[PKG-10884]: https://anaconda.atlassian.net/browse/PKG-10884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ